### PR TITLE
Improve get-starter-kit.sh

### DIFF
--- a/get-starter-kit.sh
+++ b/get-starter-kit.sh
@@ -15,16 +15,17 @@ set -o errexit -o nounset -o pipefail
 
 # Set Starterkit version
 STARTER_KIT_VERSION="${1:-latest}"
+STARTER_KIT_PROJECT="${2:-Orange-OpenSource/AWSTerraformStarterKit}"
 
 if [ "$STARTER_KIT_VERSION" == "latest" ]; then
 
-    LOCATION=$(curl -s https://api.github.com/repos/Orange-OpenSource/AWSTerraformStarterKit/releases/latest  \
+    LOCATION=$(curl -s "https://api.github.com/repos/${STARTER_KIT_PROJECT}/releases/latest  \
     | grep "tag_name" \
-    | awk '{print "https://github.com/Orange-OpenSource/AWSTerraformStarterKit/archive/" substr($2, 2, length($2)-3) ".zip"}') \
+    | awk '{print "https://github.com/${STARTER_KIT_PROJECT}/archive/" substr($2, 2, length($2)-3) ".zip"}') \
     ; curl -L -o /tmp/archive.zip "$LOCATION"
 else
   curl  -L\
-   "https://github.com/Orange-OpenSource/AWSTerraformStarterKit/archive/refs/tags/${STARTER_KIT_VERSION}.zip" \
+   "https://github.com/${STARTER_KIT_PROJECT}/archive/refs/tags/${STARTER_KIT_VERSION}.zip" \
   -o /tmp/archive.zip
 fi
 

--- a/get-starter-kit.sh
+++ b/get-starter-kit.sh
@@ -14,7 +14,7 @@
 set -o errexit -o nounset -o pipefail
 
 # Set Starterkit version
-STARTER_KIT_VERSION="latest"
+STARTER_KIT_VERSION="${1:-latest}"
 
 if [ "$STARTER_KIT_VERSION" == "latest" ]; then
 

--- a/get-starter-kit.sh
+++ b/get-starter-kit.sh
@@ -17,17 +17,12 @@ set -o errexit -o nounset -o pipefail
 STARTER_KIT_VERSION="${1:-latest}"
 STARTER_KIT_PROJECT="${2:-Orange-OpenSource/AWSTerraformStarterKit}"
 
-STARTER_KIT_FORMAT="zip"
-STARTER_KIT_URL="https://github.com/${STARTER_KIT_PROJECT}"
+STARTER_KIT_FORMAT="tar"
+STARTER_KIT_URL="https://api.github.com/repos/${STARTER_KIT_PROJECT}"
+STARTER_KIT_LOCATION="${STARTER_KIT_URL}/${STARTER_KIT_FORMAT}ball/${STARTER_KIT_VERSION}"
 
 if [ "$STARTER_KIT_VERSION" == "latest" ]; then
-    STARTER_KIT_VERSION=$(curl -s "https://api.github.com/repos/${STARTER_KIT_PROJECT}/releases/latest" | jq -r ".tag_name")
+    STARTER_KIT_LOCATION=$(curl -s ${STARTER_KIT_URL}/releases/latest | jq -r ".${STARTER_KIT_FORMAT}ball_url")
 fi
 
-STARTER_KIT_LOCATION="${STARTER_KIT_URL}/archive/refs/tags/${STARTER_KIT_VERSION}.${STARTER_KIT_FORMAT}"
-curl --fail -L "${STARTER_KIT_LOCATION}" -o /tmp/archive.zip
-
-unzip /tmp/archive.zip -d .
-cp -r AWSTerraformStarterKit-*/. .
-rm -rf AWSTerraformStarterKit-*
-rm /tmp/archive.zip
+curl --fail -L "${STARTER_KIT_LOCATION}" | tar -xz --strip-components 1

--- a/get-starter-kit.sh
+++ b/get-starter-kit.sh
@@ -17,17 +17,15 @@ set -o errexit -o nounset -o pipefail
 STARTER_KIT_VERSION="${1:-latest}"
 STARTER_KIT_PROJECT="${2:-Orange-OpenSource/AWSTerraformStarterKit}"
 
-if [ "$STARTER_KIT_VERSION" == "latest" ]; then
+STARTER_KIT_FORMAT="zip"
+STARTER_KIT_URL="https://github.com/${STARTER_KIT_PROJECT}"
 
-    LOCATION=$(curl -s "https://api.github.com/repos/${STARTER_KIT_PROJECT}/releases/latest  \
-    | grep "tag_name" \
-    | awk '{print "https://github.com/${STARTER_KIT_PROJECT}/archive/" substr($2, 2, length($2)-3) ".zip"}') \
-    ; curl -L -o /tmp/archive.zip "$LOCATION"
-else
-  curl  -L\
-   "https://github.com/${STARTER_KIT_PROJECT}/archive/refs/tags/${STARTER_KIT_VERSION}.zip" \
-  -o /tmp/archive.zip
+if [ "$STARTER_KIT_VERSION" == "latest" ]; then
+    STARTER_KIT_VERSION=$(curl -s "https://api.github.com/repos/${STARTER_KIT_PROJECT}/releases/latest" | jq -r ".tag_name")
 fi
+
+STARTER_KIT_LOCATION="${STARTER_KIT_URL}/archive/refs/tags/${STARTER_KIT_VERSION}.${STARTER_KIT_FORMAT}"
+curl --fail -L "${STARTER_KIT_LOCATION}" -o /tmp/archive.zip
 
 unzip /tmp/archive.zip -d .
 cp -r AWSTerraformStarterKit-*/. .


### PR DESCRIPTION
Make version and project configurable and use tarball instead of zipfile to avoid temporary files.

N.B. : the script now uses `jq` to parse GitHub API output (as `jq` is already listed as pre-requisite in `README.md`)