### PR TITLE
Exclude parameters.auto.tfvars and common.tfvars from gitignore

### DIFF
--- a/.gitignore.dist
+++ b/.gitignore.dist
@@ -17,6 +17,8 @@ crash.*.log
 # to change depending on the environment.
 *.tfvars
 *.tfvars.json
+!parameters.auto.tfvars
+!common.tfvars
 
 # Ignore override files as they are usually used to override resources locally and so
 # are not checked in


### PR DESCRIPTION
In .gitignore.dist we have *.tfvars and *.tfvars.json which make git ignores `parameters.auto.tfvars`  which is required for `Makefile` plan target.
As this file is not versionned, when you clone project and run a plan target as the `terraform_plan_commands` checks for `CONFIG_FILE` existance it fails. The default config file `parameters.auto.tfvars` must be excluded from `.gitignore.dist` file to be versionned.
This change excludes `parameters.auto.tfvars` and `common.tfvars` from `.gitignore.dist`.