### PR TITLE
Fix tfenv terraform version not overridable at runtime

### DIFF
--- a/automation/TFEnv/Dockerfile
+++ b/automation/TFEnv/Dockerfile
@@ -26,6 +26,8 @@ RUN wget -O /tmp/tfenv.tar.gz "https://github.com/tfutils/tfenv/archive/refs/tag
 ENV TFENV_ROOT /usr/local/lib/tfenv
 
 ENV TFENV_CONFIG_DIR /var/tfenv
+ENV TFENV_TERRAFORM_VERSION ""
+
 VOLUME /var/tfenv
 
 ENTRYPOINT ["/usr/local/bin/terraform"]

--- a/automation/TFEnv/Dockerfile
+++ b/automation/TFEnv/Dockerfile
@@ -21,11 +21,14 @@ RUN wget -O /tmp/tfenv.tar.gz "https://github.com/tfutils/tfenv/archive/refs/tag
     && mv "/tmp/tfenv-${TFENV_VERSION}/LICENSE" /usr/local/share/licenses/tfenv \
     && rm -rf /tmp/tfenv* \
     && mkdir /var/tfenv \
-    && chmod 777 /var/tfenv \
+    && touch /var/tfenv/version \
+    && echo "latest" > /ver/tfenv/version \
+    && chmod 777 -R /var/tfenv \
     ;
 ENV TFENV_ROOT /usr/local/lib/tfenv
 
 ENV TFENV_CONFIG_DIR /var/tfenv
+
 ENV TFENV_TERRAFORM_VERSION ""
 
 VOLUME /var/tfenv


### PR DESCRIPTION
Terraform version defined in a `.terraform-version` file is ignored at runtime when executing terraform command. The latest terraform version is always used unless if you set the `TFENV_TERRAFORM_VERSION` value to an empty string (`""`) which make tfenv behave as expected by reading the correct version to install from the `.terraform-version` if it exists.

This change fix that behaviour so tfenv will choose `.terraform-version` file version if the file exists and use the latest available terraform version if no version provided.

tfenv image must be rebuilt for this change to be effective. Local tfenv image must be deleted so it cant re-built. You can use this command to do so `docker rmi $(docker image list --filter=reference=tfenv -q)`.