### PR TITLE
Add corkscrew for ssh over httpproxy

### DIFF
--- a/automation/TFEnv/Dockerfile
+++ b/automation/TFEnv/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add --no-cache --purge \
     python3 py3-pip \
     git \
     wget \
+    openssh-client \
     ;
 
 ARG TFENV_VERSION

--- a/automation/TFEnv/Dockerfile
+++ b/automation/TFEnv/Dockerfile
@@ -10,6 +10,12 @@ RUN apk add --no-cache --purge \
     openssh-client \
     ;
 
+RUN apk --update --no-cache --allow-untrusted --repository http://dl-cdn.alpinelinux.org/alpine/edge/community add \
+    corkscrew \
+    && rm -rf /var/cache/apk/* \
+          /tmp/* \
+          /var/tmp/*
+
 ARG TFENV_VERSION
 
 RUN wget -O /tmp/tfenv.tar.gz "https://github.com/tfutils/tfenv/archive/refs/tags/v${TFENV_VERSION}.tar.gz" \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - /etc/passwd:/etc/passwd:ro
       - /etc/group:/etc/group:ro
       - ./:/workdir
+      - $HOME/.ssh:$HOME/.ssh
       - $HOME/.terraformrc:$HOME/.terraformrc
       - $HOME/.terraform.d:$HOME/.terraform.d
     working_dir: /workdir


### PR DESCRIPTION
This pull request adds corkscrew as a tool for ssh over http proxy. This fixes #23 

For information about corkscrew refers to [Corkscrew Git repository](https://github.com/bryanpkc/corkscrew)