### PR TITLE
fix error with plans containing 'name' in their name

### DIFF
--- a/automation/jinja2/render.py
+++ b/automation/jinja2/render.py
@@ -53,7 +53,7 @@ class Render:
             var_data = yaml.full_load(f)
         # compute execution plan
         for idx in range(len(var_data['plans'])):
-            var_data['plans'][idx] = var_data['plans'][idx] if 'name' in var_data['plans'][idx] else {
+            var_data['plans'][idx] = var_data['plans'][idx] if var_data['plans'][idx].startswith('name: ') else {
                 'name': var_data['plans'][idx]} # this is for backward compatiblity
         exec_plan = compute_deps.build_exec_plan(plans=var_data['plans'])
         var_data['exec_plan'] = exec_plan


### PR DESCRIPTION
If a plan contains "name" in his name, for instance "terraform/compute/namespace" make start failed with this trace :

Traceback (most recent call last):
  File "/scripts/entities/render.py", line 89, in <module>
    main()
  File "/scripts/entities/render.py", line 85, in main
    sys.stdout.write(Render(sys.argv[1], sys.argv[2]).rend_template())
  File "/scripts/entities/render.py", line 58, in rend_template
    exec_plan = compute_deps.build_exec_plan(plans=var_data['plans'])
  File "/scripts/entities/compute_deps.py", line 32, in build_exec_plan
    schedule(exec_plan, plan, default_exec_order)
  File "/scripts/entities/compute_deps.py", line 23, in schedule
    old_exec_order = get_current_exec_order(exec_plan=exec_plan, plan_name=plan.get('name'))
AttributeError: 'str' object has no attribute 'get'
